### PR TITLE
Fixed Null pointer exception

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -28,3 +28,5 @@
   @com.google.gson.annotations.SerializedName <fields>;
 
 }
+-keep class com.my.kizzy.ui.screen.nintendo.* { <fields>; }
+


### PR DESCRIPTION
Fixed Null pointer exception when opening Nintendo Rpc screen.

The solution was to make the proguard to skip obfuscation of Data class [Games.kt](https://github.com/dead8309/Kizzy-compose/blob/60d086d101166df2d78a016d74bba644d707ec23/app/src/main/java/com/my/kizzy/ui/screen/nintendo/Games.kt).