### PR TITLE
Fixed a critical issue

### DIFF
--- a/app/src/main/java/com/my/kizzy/rpc/ImageResolver.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/ImageResolver.kt
@@ -141,8 +141,9 @@ class ImageResolver {
             .addFormDataPart("content", "${file.name} from Rpc")
             .build()
 
-        var url = Prefs[RPC_USE_CUSTOM_WEBHOOK, URLS.random()]
-        if (url.compareTo(BuildConfig.RPC_IMAGE_API) < 10) url = URLS.random()
+        var url = Prefs[RPC_USE_CUSTOM_WEBHOOK, ""]
+        if (!url.startsWith("https://discord.com/api/webhooks"))
+            url = URLS.random()
         val req: Request = Request.Builder()
             .url(url)
             .post(body)

--- a/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
@@ -422,9 +422,11 @@ private fun getAssets(rpcImage: RpcImage.BitmapImage): String? {
      if (savedImages.containsKey(schema))
            return savedImages[schema]
      else {
-           val result = ImageResolver().uploadImage(ImageResolver().saveIcon(rpcImage.file,rpcImage.bitmap))
-           savedImages[schema] = result
+           val result: String? = ImageResolver().uploadImage(ImageResolver().saveIcon(rpcImage.file,rpcImage.bitmap))
+           result?.let {
+           savedImages[schema] = it
            Prefs[Prefs.SAVED_ARTWORK] = Gson().toJson(savedImages)
+           }
            return result
      }
 }

--- a/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
@@ -408,7 +408,22 @@ private fun RpcImage?.resolveImage(): String? {
         is RpcImage.ApplicationIcon -> ImageResolver().resolveImageOfAppIcon(this.packageName,this.context)
         is RpcImage.DiscordImage -> "mp:${this.image}"
         is RpcImage.ExternalImage -> ImageResolver().resolveImageFromUrl(this.image)
-        is RpcImage.BitmapImage -> ImageResolver().uploadImage(ImageResolver().saveIcon(this.file,this.bitmap))
+        is RpcImage.BitmapImage -> getAssets(this)
         else -> null
     }
+}
+
+private getAssets(val rpcImage: RpcImage): String?{
+     val data = Prefs[Prefs.SAVED_ARTWORK, "{}"]
+     val schema = "${rpcImage.packageName}:${rpcImage.title}"
+     val savedImages = Gson().fromJson<HashMap<String, String>>(data,
+            object : TypeToken<HashMap<String, String>>() {}.type)
+     if (savedImages.containsKey(schema))
+           return savedImages[schema]
+     else {
+           val result = ImageResolver().uploadImage(ImageResolver().saveIcon(rpcImage.file,rpcImage.bitmap))
+           saved_images[schema] = result
+           Prefs[Prefs.SAVED_ARTWORK] = Gson().toJson(saved_images)
+           return result
+     }
 }

--- a/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
@@ -413,7 +413,7 @@ private fun RpcImage?.resolveImage(): String? {
     }
 }
 
-private getAssets(val rpcImage: RpcImage.BitmapImage): String? {
+private fun getAssets(val rpcImage: RpcImage.BitmapImage): String? {
      val data = Prefs[Prefs.SAVED_ARTWORK, "{}"]
      val schema = "${rpcImage.packageName}:${rpcImage.title}"
      val savedImages = Gson().fromJson<HashMap<String, String>>(data,

--- a/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
@@ -413,7 +413,7 @@ private fun RpcImage?.resolveImage(): String? {
     }
 }
 
-private getAssets(val rpcImage: RpcImage): String?{
+private getAssets(val rpcImage: RpcImage.BitmapImage): String? {
      val data = Prefs[Prefs.SAVED_ARTWORK, "{}"]
      val schema = "${rpcImage.packageName}:${rpcImage.title}"
      val savedImages = Gson().fromJson<HashMap<String, String>>(data,
@@ -422,8 +422,8 @@ private getAssets(val rpcImage: RpcImage): String?{
            return savedImages[schema]
      else {
            val result = ImageResolver().uploadImage(ImageResolver().saveIcon(rpcImage.file,rpcImage.bitmap))
-           saved_images[schema] = result
-           Prefs[Prefs.SAVED_ARTWORK] = Gson().toJson(saved_images)
+           savedImages[schema] = result
+           Prefs[Prefs.SAVED_ARTWORK] = Gson().toJson(savedImages)
            return result
      }
 }

--- a/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/KizzyRPC.kt
@@ -13,6 +13,7 @@ import org.java_websocket.handshake.ServerHandshake
 import java.net.URI
 import java.net.URISyntaxException
 import javax.net.ssl.SSLParameters
+import com.my.kizzy.utils.Prefs
 
 class KizzyRPC(
     var token: String,
@@ -413,7 +414,7 @@ private fun RpcImage?.resolveImage(): String? {
     }
 }
 
-private fun getAssets(val rpcImage: RpcImage.BitmapImage): String? {
+private fun getAssets(rpcImage: RpcImage.BitmapImage): String? {
      val data = Prefs[Prefs.SAVED_ARTWORK, "{}"]
      val schema = "${rpcImage.packageName}:${rpcImage.title}"
      val savedImages = Gson().fromJson<HashMap<String, String>>(data,

--- a/app/src/main/java/com/my/kizzy/rpc/RpcImage.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/RpcImage.kt
@@ -9,5 +9,5 @@ sealed class RpcImage {
     class DiscordImage(val image: String): RpcImage()
     class ExternalImage(val image: String): RpcImage()
     class ApplicationIcon(val packageName: String, val context: Context): RpcImage()
-    class BitmapImage(val file: File,val bitmap: Bitmap?,val packageName: String): RpcImage()
+    class BitmapImage(val file: File,val bitmap: Bitmap?,val packageName: String,val title: String): RpcImage()
 }

--- a/app/src/main/java/com/my/kizzy/rpc/RpcImage.kt
+++ b/app/src/main/java/com/my/kizzy/rpc/RpcImage.kt
@@ -9,5 +9,5 @@ sealed class RpcImage {
     class DiscordImage(val image: String): RpcImage()
     class ExternalImage(val image: String): RpcImage()
     class ApplicationIcon(val packageName: String, val context: Context): RpcImage()
-    class BitmapImage(val file: File,val bitmap: Bitmap?): RpcImage()
+    class BitmapImage(val file: File,val bitmap: Bitmap?,val packageName: String): RpcImage()
 }

--- a/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
+++ b/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
@@ -80,15 +80,14 @@ class MediaRpcService : Service() {
                                 RpcImage.ApplicationIcon(mediaController.packageName, this)
                                    else null
                         val bitmap = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
-                        if (bitmap != null){
-                            smallIcon = app_icon
-                            app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap)
-                        }
-                        else smallIcon = null
                         if (newTitle != null) {
                             if (newTitle != TITLE) {
                                 TITLE = newTitle
                                 App_Name = getAppName(mediaController.packageName)
+                                if (bitmap != null){
+                                   smallIcon = app_icon
+                                   app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap)
+                                  } else smallIcon = null
                             }
                         }
                     } else {

--- a/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
+++ b/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
@@ -86,7 +86,7 @@ class MediaRpcService : Service() {
                                    else null
                                 if (bitmap != null){
                                    smallIcon = app_icon
-                                   app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap)
+                                   app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap,mediaController.packageName)
                                   } else smallIcon = null
                             }
                         }

--- a/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
+++ b/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
@@ -74,16 +74,16 @@ class MediaRpcService : Service() {
                         val mediaController = sessions[0]
                         val metadata = mediaController.metadata
                         val newTitle = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE)
-                        author = if (Prefs[MEDIA_RPC_ARTIST_NAME, false]) getArtistOrAuthor(metadata)
-                                 else null
-                        app_icon = if (Prefs[MEDIA_RPC_APP_ICON, false])
-                                RpcImage.ApplicationIcon(mediaController.packageName, this)
-                                   else null
                         val bitmap = metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)
                         if (newTitle != null) {
                             if (newTitle != TITLE) {
                                 TITLE = newTitle
                                 App_Name = getAppName(mediaController.packageName)
+                                author = if (Prefs[MEDIA_RPC_ARTIST_NAME, false]) getArtistOrAuthor(metadata)
+                                 else null
+                                app_icon = if (Prefs[MEDIA_RPC_APP_ICON, false])
+                                RpcImage.ApplicationIcon(mediaController.packageName, this)
+                                   else null
                                 if (bitmap != null){
                                    smallIcon = app_icon
                                    app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap)

--- a/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
+++ b/app/src/main/java/com/my/kizzy/service/MediaRpcService.kt
@@ -86,7 +86,7 @@ class MediaRpcService : Service() {
                                    else null
                                 if (bitmap != null){
                                    smallIcon = app_icon
-                                   app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap,mediaController.packageName)
+                                   app_icon = RpcImage.BitmapImage(File(this.filesDir.toString() + File.separator + "art"),bitmap,mediaController.packageName,TITLE)
                                   } else smallIcon = null
                             }
                         }

--- a/app/src/main/java/com/my/kizzy/ui/screen/settings/rpc_settings/RpcSettings.kt
+++ b/app/src/main/java/com/my/kizzy/ui/screen/settings/rpc_settings/RpcSettings.kt
@@ -70,6 +70,7 @@ fun RpcSettings(onBackPressed: () -> Boolean) {
                     icon = Icons.Default.DeleteForever
                 ) {
                     Prefs.remove(Prefs.SAVED_IMAGES)
+                    Prefs.remove(Prefs.SAVED_ARTWORK)
                     Toast.makeText(context, "Done", Toast.LENGTH_SHORT).show()
                 }
             }
@@ -79,7 +80,9 @@ fun RpcSettings(onBackPressed: () -> Boolean) {
                 onDismissRequest = { dismiss = !dismiss },
                 confirmButton = {
                     TextButton(onClick = {
-                        Prefs[Prefs.RPC_USE_CUSTOM_WEBHOOK] = "$useCustomWebhook?wait=true"
+                        if(useCustomWebhook.startsWith("https://discord.com/api/webhooks"))
+                           Prefs[Prefs.RPC_USE_CUSTOM_WEBHOOK] = "$useCustomWebhook?wait=true"
+                        else Prefs.remove(Prefs.RPC_USE_CUSTOM_WEBHOOK)
                     }) {
                         Text(text = "Save")
                     }

--- a/app/src/main/java/com/my/kizzy/utils/Prefs.kt
+++ b/app/src/main/java/com/my/kizzy/utils/Prefs.kt
@@ -89,4 +89,6 @@ object Prefs {
 
     // Saved Image Asset ids
     const val SAVED_IMAGES = "saved_images"
+    // Saved ArtWork
+    const val SAVED_ARTWORK = "saved_artwork"
 }


### PR DESCRIPTION
### 1. Fixed an issue with media rpc where large image:

> Shows correct image for sometime then it starts showing app logo.

> Blinks every 5 second on discord app.
It was consuming more webhook resources by sending the image every 5 second.

#### Replaced previous practice with SharedPreferences to store artwork data as
```js
"${appPackageName}:${mediaTitle}"
```
### 2. Fixed Custom Webhook setting

> Now you can easily paste a discord webhook link and app will use it to send data for Media and Apps Rpc