### PR TITLE
feat(media): add album name toggle & report correct playback position

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">

--- a/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
+++ b/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
@@ -112,6 +112,7 @@ object Prefs {
 
     //Media Rpc Preferences
     const val MEDIA_RPC_ARTIST_NAME = "media_rpc_artist_name"
+    const val MEDIA_RPC_ALBUM_NAME = "media_rpc_album_name"
     const val MEDIA_RPC_APP_ICON = "media_rpc_app_icon"
     const val MEDIA_RPC_ENABLE_TIMESTAMPS = "enable_timestamps"
 

--- a/common/resources/src/main/res/values-de/strings.xml
+++ b/common/resources/src/main/res/values-de/strings.xml
@@ -31,6 +31,7 @@
     <string name="credits">Credits</string>
     <string name="credits_desc">Verweise auf verwendete Bibliotheken und Mitwirkende</string>
     <string name="enable_artist_name">Künstlername aktivieren</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">App-Symbol anzeigen</string>
     <string name="enable_timestamps">Zeitstempel aktivieren</string>
     <string name="text_after_permission_denied">Der Speicherzugriff ist wichtig für diese Anwendung, um Konfigurationen in öffentlichen Verzeichnissen zu speichern. Bitte erteile die Erlaubnis.</string>

--- a/common/resources/src/main/res/values-fa/strings.xml
+++ b/common/resources/src/main/res/values-fa/strings.xml
@@ -31,6 +31,7 @@
     <string name="credits">سازندگان</string>
     <string name="credits_desc">سازندگان کتابخانه ها و مشارکت کنندگان</string>
     <string name="enable_artist_name">فعال کردن نام هنرمند</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">نمایش نماد برنامه</string>
     <string name="enable_timestamps">فعال کردن رویداد ها</string>
     <string name="text_after_permission_denied">دسترسی به فضای ذخیره سازی برای این برنامه برای ذخیره تنظیمات در پوشه های عمومی مهم است. لطفا اجازه بدهید</string>

--- a/common/resources/src/main/res/values-fil/strings.xml
+++ b/common/resources/src/main/res/values-fil/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Mga kredito</string>
     <string name="credits_desc">Mga kredito sa mga ginamit na aklatan at mga nag-aambag</string>
     <string name="enable_artist_name">Paganahin ang Pangalan ng Artist</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Ipakita ang Icon ng App</string>
     <string name="enable_timestamps">Paganahin ang mga Timestamp</string>
     <string name="text_after_permission_denied">Mahalaga ang access sa storage para sa app na ito upang mag-imbak ng mga config sa mga pampublikong direktoryo. Mangyaring bigyan ang pahintulot.</string>

--- a/common/resources/src/main/res/values-fr/strings.xml
+++ b/common/resources/src/main/res/values-fr/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Crédits</string>
     <string name="credits_desc">Crédits aux bibliothèques utilisées et aux contributeurs</string>
     <string name="enable_artist_name">Activer le nom de l\'artiste</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Afficher l\'icône de l\'application</string>
     <string name="enable_timestamps">Activer le Timestamps</string>
     <string name="text_after_permission_denied">L\'accès au stockage est important pour cette application afin de stocker les configurations dans des répertoires publics. Veuillez accorder cette permission.</string>

--- a/common/resources/src/main/res/values-hr/strings.xml
+++ b/common/resources/src/main/res/values-hr/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Zasluge</string>
     <string name="credits_desc">Zasluge za korištene knjižnice i doprinositelje</string>
     <string name="enable_artist_name">Omogući naziv umjetnika</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Prikaži ikonu aplikacije</string>
     <string name="enable_timestamps">Omogući vremenske oznake</string>
     <string name="text_after_permission_denied">Pristup pohrani je važan za ovu aplikaciju kako bi se postavke pohranile u javne direktorije. Molimo odobrite pristup.</string>

--- a/common/resources/src/main/res/values-in/strings.xml
+++ b/common/resources/src/main/res/values-in/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Kredit</string>
     <string name="credits_desc">Kredit untuk libraries yang digunakan dan Kontributor</string>
     <string name="enable_artist_name">Nyalakan Nama Artis</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Tampilkan Ikon Aplikasi</string>
     <string name="enable_timestamps">Nyalakan Stempel Waktu</string>
     <string name="text_after_permission_denied">Akses penyimpanan penting bagi aplikasi ini untuk menyimpan konfigurasi di folder publik.</string>

--- a/common/resources/src/main/res/values-it/strings.xml
+++ b/common/resources/src/main/res/values-it/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Crediti</string>
     <string name="credits_desc">Crediti alle librerie utilizzate e ai collaboratori</string>
     <string name="enable_artist_name">Abilita Nome Artista</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Mostra Icona App</string>
     <string name="enable_timestamps">Abilita Tempo Trascorso</string>
     <string name="text_after_permission_denied">Accesso ai dati di archiviazione necessario per salvare le configurazioni nelle cartelle pubbliche. Si prega di concedere il permesso.</string>

--- a/common/resources/src/main/res/values-ja/strings.xml
+++ b/common/resources/src/main/res/values-ja/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">クレジット</string>
     <string name="credits_desc">使用したライブラリと貢献者へのクレジット</string>
     <string name="enable_artist_name">アーティスト名を表示</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">アプリアイコンを表示</string>
     <string name="enable_timestamps">経過日時を表示</string>
     <string name="text_after_permission_denied">このアプリでは、構成ファイルを保存、読み込み、削除するためにストレージへのアクセスが必要です。権限を付与してください。</string>

--- a/common/resources/src/main/res/values-mm/strings.xml
+++ b/common/resources/src/main/res/values-mm/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">ခရက်ဒစ်</string>
     <string name="credits_desc">ယူသုံးထားသော libraries နှင့် contributors အတွက် ခရက်ဒစ်</string>
     <string name="enable_artist_name">အနုပညာရှင်နာမည်ကို သုံးပါ</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">အက်ပ်အိုင်ကွန် ပြပါ</string>
     <string name="enable_timestamps">အချိန်ပြစာကို သုံးပါ</string>
     <string name="text_after_permission_denied">Storage access is important for this app to store configs in public directories. Please grant the permission.</string>

--- a/common/resources/src/main/res/values-nl/strings.xml
+++ b/common/resources/src/main/res/values-nl/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Credits</string>
     <string name="credits_desc">Credits to libraries used and contributors</string>
     <string name="enable_artist_name">Laat artiest naam zien</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Laat app icoon zien</string>
     <string name="enable_timestamps">Laat verstreken tijd zien</string>
     <string name="text_after_permission_denied">Geef de app permissie om de opslag te gebruiken, het is erg belangrijk en word gebruikt om de configuraties op te slaan.</string>

--- a/common/resources/src/main/res/values-pl/strings.xml
+++ b/common/resources/src/main/res/values-pl/strings.xml
@@ -31,6 +31,7 @@
     <string name="credits">Podziękowania</string>
     <string name="credits_desc">Podziękowania dla używanych bibliotek i użytkowników</string>
     <string name="enable_artist_name">Włącz Nazwę Artysty</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Pokaż Ikonę Aplikacji</string>
     <string name="enable_timestamps">Włącz Znaczniki Czasu</string>
     <string name="text_after_permission_denied">Dostęp do pamięci jest ważny dla tej aplikacji do przechowywania konfiguracji w katalogach publicznych. Proszę o pozwolenie na dostęp</string>

--- a/common/resources/src/main/res/values-pt/strings.xml
+++ b/common/resources/src/main/res/values-pt/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Créditos</string>
     <string name="credits_desc">Créditos às bibliotecas utilizadas e os colaboradores</string>
     <string name="enable_artist_name">Ativar Nome do Artista</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Mostrar Ícone do Aplicativo</string>
     <string name="enable_timestamps">Ativar Tempo de Atividade</string>
     <string name="text_after_permission_denied">O acesso à memória é importante para este aplicativo armazenar configurações em diretórios públicos. Por favor, conceda permissão.</string>

--- a/common/resources/src/main/res/values-ru/strings.xml
+++ b/common/resources/src/main/res/values-ru/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Спасибо этим людям!</string>
     <string name="credits_desc">Упоминания используемых библиотек и авторов</string>
     <string name="enable_artist_name">Включить имя артиста</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Показывать иконку приложения</string>
     <string name="enable_timestamps">Включить временные метки</string>
     <string name="text_after_permission_denied">Доступ к хранилищу важен для этого приложения, чтобы хранить конфигурации в общедоступных каталогах. Пожалуйста, дайте разрешение.</string>

--- a/common/resources/src/main/res/values-th/strings.xml
+++ b/common/resources/src/main/res/values-th/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">เครดิต</string>
     <string name="credits_desc">เครดิตแก่ libraries ที่ใช้และผู้ที่มีส่วนร่วมที่ทำให้แอพนี้เป็นแอพสุดเจ๋ง!</string>
     <string name="enable_artist_name">เปิดใช้งาน การแสดงชื่อของศิลปินสุดแสนวิเศษ</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">แสดงไอคอนของแอพสุดเฟี้ยว</string>
     <string name="enable_timestamps">เปิดใช้งานการประทับเวลา</string>
     <string name="text_after_permission_denied">เฮ้! การเข้าถึงพื้นที่จัดเก็บข้อมูลในโทรศัพท์ของคุณเป็นความสำคัญต่อแอพในการเก็บพวกเหล่าการตั้งค่าต่างๆของคุณให้มี ที่ซุกหัวนอนภายในพื้นที่โทรศัพท์อ่ะนะ ขอมาขนาดนี้ให้สิทธิ์การเข้าถึงพื้นที่จัดเก็บมือถือด้วยล่ะ มันง่ายกว่าไปรักเขาข้างเดียวอีก!</string>

--- a/common/resources/src/main/res/values-tr/strings.xml
+++ b/common/resources/src/main/res/values-tr/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Katkıda Bulunanlar</string>
     <string name="credits_desc">Kullanılan kitaplıklar ve Katkıda bulunan çevirmenler</string>
     <string name="enable_artist_name">Sanatçı İsmini Etkinleştir</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Uygulama Simgesini Göster</string>
     <string name="enable_timestamps">Zaman Bilgisini Etkinleştir</string>
     <string name="text_after_permission_denied">Depolama erişimi bu uygulama için herkese açık dizinlerde yapılandırma kaydetmek için önemlidir. Lütfen izin verin.</string>

--- a/common/resources/src/main/res/values-vi/strings.xml
+++ b/common/resources/src/main/res/values-vi/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">Ghi công</string>
     <string name="credits_desc">Ghi công cho các thư viện được sử dụng và các người đóng góp</string>
     <string name="enable_artist_name">Bật tên nghệ sĩ</string>
+    <string name="enable_album_name">Bật tên album</string>
     <string name="show_app_icon">Hiển thị biểu tượng ứng dụng</string>
     <string name="enable_timestamps">Bật đồng hồ đếm thời gian</string>
     <string name="text_after_permission_denied">Quyền truy cập vào bộ nhớ rất quan trọng đối với ứng dụng này để lưu trữ các tệp cấu hình trong các thư mục. Vui lòng cấp quyền.</string>

--- a/common/resources/src/main/res/values-zh/strings.xml
+++ b/common/resources/src/main/res/values-zh/strings.xml
@@ -30,6 +30,7 @@
     <string name="credits">捐款</string>
     <string name="credits_desc">捐款給使用的資料庫和奉獻者</string>
     <string name="enable_artist_name">啟用顯示作家名字</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">顯示程式名字</string>
     <string name="enable_timestamps">啟用時間</string>
     <string name="text_after_permission_denied">你必須授權儲存權限以儲存配置</string>

--- a/common/resources/src/main/res/values/strings.xml
+++ b/common/resources/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="credits">Credits</string>
     <string name="credits_desc">Credits to libraries used and contributors</string>
     <string name="enable_artist_name">Enable Artist Name</string>
+    <string name="enable_album_name">Enable Album Name</string>
     <string name="show_app_icon">Show App Icon</string>
     <string name="enable_timestamps">Enable Timestamps</string>
     <string name="text_after_permission_denied">Storage access is important for this app to store configs in public directories. Please grant the permission.</string>

--- a/data/src/main/java/com/my/kizzy/data/get_current_data/AppTracker.kt
+++ b/data/src/main/java/com/my/kizzy/data/get_current_data/AppTracker.kt
@@ -26,16 +26,11 @@ class AppTracker @Inject constructor(
     private val getCurrentlyRunningApp: GetCurrentlyRunningApp,
     private val getCurrentPlayingMedia: GetCurrentPlayingMedia
 ) {
-
     fun getCurrentAppData() = flow {
-        var songTitle = "" // Title::packageName
         while (currentCoroutineContext().isActive) {
             val getCurrentMedia = getCurrentPlayingMedia()
             if (getCurrentMedia.name.isNotEmpty()) {
-                if (songTitle != getCurrentMedia.packageName) {
-                    songTitle = getCurrentMedia.packageName
-                    emit(getCurrentMedia)
-                }
+                emit(getCurrentMedia)
             } else {
                 val getCurrentApp = getCurrentlyRunningApp()
                 if (getCurrentApp.name.isNotEmpty()) {

--- a/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
+++ b/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
@@ -46,11 +46,16 @@ class GetCurrentPlayingMedia @Inject constructor(
                 if (Prefs[Prefs.MEDIA_RPC_ARTIST_NAME, false])
                 metadata?.let { metadataResolver.getArtistOrAuthor(it) }
                 else null
+            val album =
+                if (Prefs[Prefs.MEDIA_RPC_ALBUM_NAME, false])
+                metadata?.let { metadataResolver.getAlbum(it) }
+                else null
             val bitmap = metadata?.let { metadataResolver.getCoverArt(it) }
             val duration = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)
             duration?.let {
                 if (it != 0L) timestamps = Timestamps(
-                    end = System.currentTimeMillis() + duration, start = System.currentTimeMillis()
+                    end = System.currentTimeMillis() + duration - (mediaController.playbackState?.position ?: 0L),
+                    start = System.currentTimeMillis() - (mediaController.playbackState?.position ?: 0L)
                 )
             }
             if (title != null) {
@@ -72,6 +77,8 @@ class GetCurrentPlayingMedia @Inject constructor(
                     state = author,
                     largeImage = largeIcon,
                     smallImage = smallIcon,
+                    largeText = album,
+                    smallText = appName,
                     packageName = "$title::${mediaController.packageName}",
                     time = timestamps.takeIf { it != null })
             }

--- a/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
+++ b/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
@@ -17,6 +17,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.media.MediaMetadata
 import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState.STATE_PLAYING
 import com.blankj.utilcode.util.AppUtils
 import com.my.kizzy.data.rpc.CommonRpc
 import com.my.kizzy.data.rpc.RpcImage
@@ -53,7 +54,7 @@ class GetCurrentPlayingMedia @Inject constructor(
             val bitmap = metadata?.let { metadataResolver.getCoverArt(it) }
             val duration = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)
             duration?.let {
-                if (it != 0L) timestamps = Timestamps(
+                if (it != 0L && mediaController.playbackState?.state == STATE_PLAYING) timestamps = Timestamps(
                     end = System.currentTimeMillis() + duration - (mediaController.playbackState?.position ?: 0L),
                     start = System.currentTimeMillis() - (mediaController.playbackState?.position ?: 0L)
                 )

--- a/data/src/main/java/com/my/kizzy/data/get_current_data/media/MetadataResolver.kt
+++ b/data/src/main/java/com/my/kizzy/data/get_current_data/media/MetadataResolver.kt
@@ -25,10 +25,16 @@ class MetadataResolver @Inject constructor() {
     }
 
     fun getArtistOrAuthor(metadata: MediaMetadata): String? {
-        return if (metadata.getString(MediaMetadata.METADATA_KEY_ARTIST) != null) "by " + metadata.getString(
+        return if (!metadata.getString(MediaMetadata.METADATA_KEY_ARTIST).isNullOrEmpty()) "by " + metadata.getString(
             MediaMetadata.METADATA_KEY_ARTIST
-        ) else if (metadata.getString(MediaMetadata.METADATA_KEY_AUTHOR) != null) "by " + metadata.getString(
+        ) else if (!metadata.getString(MediaMetadata.METADATA_KEY_AUTHOR).isNullOrEmpty()) "by " + metadata.getString(
             MediaMetadata.METADATA_KEY_AUTHOR
+        ) else null
+    }
+
+    fun getAlbum(metadata: MediaMetadata): String? {
+        return if (!metadata.getString(MediaMetadata.METADATA_KEY_ALBUM).isNullOrEmpty()) metadata.getString(
+            MediaMetadata.METADATA_KEY_ALBUM
         ) else null
     }
 }

--- a/data/src/main/java/com/my/kizzy/data/rpc/CommonRpc.kt
+++ b/data/src/main/java/com/my/kizzy/data/rpc/CommonRpc.kt
@@ -20,6 +20,8 @@ data class CommonRpc(
     val state: String? = "",
     val largeImage: RpcImage? = null,
     val smallImage: RpcImage? = null,
+    var largeText: String? = "",
+    var smallText: String? = "",
     val time: Timestamps? = null,
     val packageName: String = ""
 )

--- a/data/src/main/java/com/my/kizzy/data/rpc/KizzyRPC.kt
+++ b/data/src/main/java/com/my/kizzy/data/rpc/KizzyRPC.kt
@@ -268,39 +268,7 @@ class KizzyRPC(
         discordWebSocket.sendActivity(presence)
     }
 
-    suspend fun updateRPC(
-        name: String,
-        details: String?,
-        state: String?,
-        large_image: RpcImage?,
-        small_image: RpcImage?,
-        enableTimestamps: Boolean,
-        time: Long
-    ) {
-        discordWebSocket.sendActivity(
-            Presence(
-                activities = listOf(
-                    Activity(name = name,
-                        details = details,
-                        state = state,
-                        type = Prefs[CUSTOM_ACTIVITY_TYPE, 0],
-                        timestamps = Timestamps(start = time).takeIf { enableTimestamps },
-                        assets = Assets(
-                            largeImage = large_image?.resolveImage(kizzyRepository),
-                            smallImage = small_image?.resolveImage(kizzyRepository)
-                        ).takeIf { large_image != null || small_image != null },
-                        buttons = buttons.takeIf { it.size > 0 },
-                        metadata = Metadata(buttonUrls = buttonUrl).takeIf { buttonUrl.size > 0 },
-                        applicationId = Constants.APPLICATION_ID.takeIf { buttons.size > 0 })
-                ),
-                afk = true,
-                since = time,
-                status = Constants.DND
-            )
-        )
-    }
-
-    suspend fun updateRPC(commonRpc: CommonRpc) {
+    suspend fun updateRPC(commonRpc: CommonRpc, enableTimestamps: Boolean? = true) {
         if (!discordWebSocket.isActive) return
         var time = Timestamps(start = startTimestamps)
         if (commonRpc.time != null)
@@ -313,10 +281,12 @@ class KizzyRPC(
                         details = commonRpc.details?.takeIf { it.isNotEmpty() },
                         state = commonRpc.state?.takeIf { it.isNotEmpty() },
                         type = Prefs[CUSTOM_ACTIVITY_TYPE, 0],
-                        timestamps = time,
+                        timestamps = time.takeIf { enableTimestamps == true },
                         assets = Assets(
                                 largeImage = commonRpc.largeImage?.resolveImage(kizzyRepository),
-                                smallImage = commonRpc.smallImage?.resolveImage(kizzyRepository)
+                                smallImage = commonRpc.smallImage?.resolveImage(kizzyRepository),
+                                largeText = commonRpc.largeText,
+                                smallText = commonRpc.smallText,
                             ).takeIf { commonRpc.largeImage != null || commonRpc.smallImage != null },
                         buttons = buttons.takeIf { buttons.size > 0 },
                         metadata = Metadata(buttonUrls = buttonUrl).takeIf { buttonUrl.size > 0 },

--- a/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
+++ b/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.Audiotrack
+import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
@@ -37,6 +38,7 @@ import com.my.kizzy.feature_rpc_base.services.MediaRpcService
 import com.my.kizzy.preference.Prefs
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_APP_ICON
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_ARTIST_NAME
+import com.my.kizzy.preference.Prefs.MEDIA_RPC_ALBUM_NAME
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_ENABLE_TIMESTAMPS
 import com.my.kizzy.resources.R
 import com.my.kizzy.ui.components.BackButton
@@ -50,6 +52,7 @@ fun MediaRPC(onBackPressed: () -> Unit) {
     val context = LocalContext.current
     var mediaRpcRunning by remember { mutableStateOf(AppUtils.mediaRpcRunning()) }
     var isArtistEnabled by remember { mutableStateOf(Prefs[MEDIA_RPC_ARTIST_NAME, false]) }
+    var isAlbumEnabled by remember { mutableStateOf(Prefs[MEDIA_RPC_ALBUM_NAME, false]) }
     var isAppIconEnabled by remember { mutableStateOf(Prefs[MEDIA_RPC_APP_ICON, false]) }
     var isTimestampsEnabled by remember { mutableStateOf(Prefs[MEDIA_RPC_ENABLE_TIMESTAMPS, false]) }
     var hasNotificationAccess by remember { mutableStateOf(context.hasNotificationAccess()) }
@@ -108,6 +111,16 @@ fun MediaRPC(onBackPressed: () -> Unit) {
                     ) {
                         isArtistEnabled = !isArtistEnabled
                         Prefs[MEDIA_RPC_ARTIST_NAME] = isArtistEnabled
+                    }
+                }
+                item {
+                    PreferenceSwitch(
+                        title = stringResource(id = R.string.enable_album_name),
+                        icon = Icons.Default.Album,
+                        isChecked = isAlbumEnabled
+                    ) {
+                        isAlbumEnabled = !isAlbumEnabled
+                        Prefs[MEDIA_RPC_ALBUM_NAME] = isAlbumEnabled
                     }
                 }
                 item {

--- a/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/ExperimentalRpc.kt
+++ b/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/ExperimentalRpc.kt
@@ -78,8 +78,8 @@ class ExperimentalRpc : Service() {
                         setName(collectedData.name)
                         setStartTimestamps(System.currentTimeMillis())
                         setStatus(Prefs[Prefs.CUSTOM_ACTIVITY_STATUS,"dnd"])
-                        setLargeImage(collectedData.largeImage)
-                        setSmallImage(collectedData.smallImage)
+                        setLargeImage(collectedData.largeImage, collectedData.largeText)
+                        setSmallImage(collectedData.smallImage, collectedData.smallText)
                         if (Prefs[Prefs.USE_RPC_BUTTONS, false]) {
                             with(rpcButtons) {
                                 setButton1(button1.takeIf { it.isNotEmpty() })

--- a/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/MediaRpcService.kt
+++ b/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/MediaRpcService.kt
@@ -62,8 +62,6 @@ class MediaRpcService : Service() {
         super.onCreate()
         val token = Prefs[TOKEN, ""]
         if (token.isEmpty()) stopSelf()
-        // TODO add time left later
-        val time = System.currentTimeMillis()
         setupWakeLock()
         val intent = Intent(this, MediaRpcService::class.java)
         intent.action = Constants.ACTION_STOP_SERVICE
@@ -102,15 +100,7 @@ class MediaRpcService : Service() {
                 when (kizzyRPC.isRpcRunning()) {
                     true -> {
                         logger.d("MediaRPC", "Updating Rpc")
-                        kizzyRPC.updateRPC(
-                            name = playingMedia.name.ifEmpty { "YouTube" },
-                            details = playingMedia.details,
-                            state = playingMedia.state,
-                            large_image = playingMedia.largeImage,
-                            small_image = playingMedia.smallImage,
-                            enableTimestamps = enableTimestamps,
-                            time = time
-                        )
+                        kizzyRPC.updateRPC(playingMedia, enableTimestamps)
                     }
 
                     false -> {
@@ -118,6 +108,8 @@ class MediaRpcService : Service() {
                             setName(playingMedia.name.ifEmpty { "YouTube" })
                             setDetails(playingMedia.details)
                             setStatus(Prefs[Prefs.CUSTOM_ACTIVITY_STATUS,"dnd"])
+                            setLargeImage(playingMedia.largeImage, if (Prefs[Prefs.MEDIA_RPC_ALBUM_NAME, false]) playingMedia.largeText else null)
+                            setSmallImage(if (Prefs[Prefs.MEDIA_RPC_APP_ICON, false]) playingMedia.smallImage else null, playingMedia.smallText)
                             if (Prefs[Prefs.USE_RPC_BUTTONS, false]) {
                                 with(rpcButtons) {
                                     setButton1(button1.takeIf { it.isNotEmpty() })


### PR DESCRIPTION
Since Discord has had better support for activity types, album names are now displayed in the Rich Presence on your profile, so it should make sense for the app to utilize them as well
Resolves #227 

![image](https://github.com/user-attachments/assets/36ae1b22-8325-45a2-93ec-2d05de61ab30)
![image](https://github.com/user-attachments/assets/3bf839d3-3c2d-40d6-9961-a331e6fd3cda)

Some other misc fixes are included:
- Report correct playback position, hide progress bar on paused by not passing end timestamp. This would also fix an issue where the timestamp gets stuck if the music player is set to Repeat One and/or is paused
- Update Media RPC to match current Experimental RPC data on media sessions
- Fix Experimental initial startup stuck having no data until user switches songs and/or album cover not fetched in time after the Rich Presence has been displayed, thus not being updated

I'll try to accommodate all changes need to be made in this PR. Thanks for the amazing project!