### PR TITLE
feat(quickie): show dialog on lock screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -59,6 +60,15 @@
         <activity
             android:name=".feature_crash_handler.CrashHandler"
             android:exported="false" />
+        <activity
+            android:name=".feature_rpc_base.services.DialogActivity"
+            android:exported="true"
+            android:theme="@style/ActivityTranslucent">
+            <intent-filter>
+                <action android:name="android.intent.action.RUN" />
+                <category android:name="android.intent.category.EMBED" />
+            </intent-filter>
+        </activity>
 
         <service
             android:name="com.my.kizzy.feature_rpc_base.services.AppDetectionService"

--- a/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/DialogActivity.kt
+++ b/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/DialogActivity.kt
@@ -1,0 +1,54 @@
+/*
+ *
+ *  ******************************************************************
+ *  *  * Copyright (C) 2022
+ *  *  * DialogActivity.kt is part of Kizzy
+ *  *  *  and can not be copied and/or distributed without the express
+ *  *  * permission of yzziK(Vaibhav)
+ *  *  *****************************************************************
+ *
+ *
+ */
+
+package com.my.kizzy.feature_rpc_base.services
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Bundle
+import androidx.appcompat.view.ContextThemeWrapper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.my.kizzy.resources.R
+
+class DialogActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (SDK_INT >= 27)
+            setShowWhenLocked(true)
+        showDialog()
+    }
+
+    private fun showDialog() {
+        val rpc = arrayOf(
+            getString(R.string.main_appDetection),
+            getString(R.string.main_mediaRpc),
+            getString(R.string.main_experimentalRpc),
+            getString(R.string.main_samsungRpc)
+        )
+        val dialog = MaterialAlertDialogBuilder(ContextThemeWrapper(this, com.my.kizzy.feature_rpc_base.R.style.MyTileDialogTheme))
+            .setTitle(getString(R.string.choose_rpc))
+            .setSingleChoiceItems(rpc, -1) { dialog, which ->
+                when (which) {
+                    0 -> startService(Intent(this, AppDetectionService::class.java))
+                    1 -> startService(Intent(this, MediaRpcService::class.java))
+                    2 -> startService(Intent(this, ExperimentalRpc::class.java))
+                    3 -> startService(Intent(this, SamsungRpcService::class.java))
+                }
+                dialog.dismiss()
+                finish()
+            }
+            .create()
+        dialog.setOnDismissListener { finish() }
+        dialog.show()
+    }
+}

--- a/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/KizzyTileService.kt
+++ b/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/KizzyTileService.kt
@@ -14,6 +14,7 @@ package com.my.kizzy.feature_rpc_base.services
 
 import android.app.Dialog
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Build
@@ -38,7 +39,13 @@ class KizzyTileService : TileService() {
                 ctx.stopService(Intent(ctx, SamsungRpcService::class.java))
             }
             Tile.STATE_INACTIVE -> {
-                showDialog(createRpcChoosingDialog(ctx))
+                if (!isLocked) {
+                    showDialog(createRpcChoosingDialog(ctx))
+                } else {
+                    val intent = Intent(ctx, DialogActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    ContextWrapper(ctx).startActivity(intent)
+                }
             }
             else -> {}
         }
@@ -125,3 +132,4 @@ class KizzyTileService : TileService() {
         val tileAdded = mutableStateOf(false)
     }
 }
+


### PR DESCRIPTION
Currently if you try to run Quickie while the device is locked it would render the dialog behind the lock screen as many times.