### PR TITLE
feat: Application filter for Media RPC

### DIFF
--- a/common/components/build.gradle.kts
+++ b/common/components/build.gradle.kts
@@ -15,4 +15,6 @@ dependencies {
     implementation (libs.coil)
     implementation (projects.common.resources)
     implementation (libs.material.icons.extended)
+    implementation (libs.blankj.utilcodex)
+    implementation (libs.glide)
 }

--- a/common/components/src/main/java/com/my/kizzy/ui/components/AppsItem.kt
+++ b/common/components/src/main/java/com/my/kizzy/ui/components/AppsItem.kt
@@ -10,7 +10,7 @@
  *
  */
 
-package com.my.kizzy.feature_apps_rpc
+package com.my.kizzy.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.blankj.utilcode.util.AppUtils
-import com.my.kizzy.ui.components.KSwitch
 import com.skydoves.landscapist.glide.GlideImage
 
 @Composable

--- a/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
+++ b/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
@@ -64,6 +64,38 @@ object Prefs {
         set(ENABLED_APPS, Json.encodeToString(enabledPackages))
     }
 
+    /**
+     * Checks if the given app is enabled in the preferences for media rpc. This is used to filter
+     * the media RPC based on the enabled media apps.
+     *
+     * @param packageName The package name of the app to check
+     */
+    fun isMediaAppEnabled(packageName: String?): Boolean {
+        val apps = get(ENABLED_MEDIA_APPS, Json.encodeToString(predefinedMediaApps))
+        val enabledPackages: ArrayList<String> = Json.decodeFromString(apps)
+        return enabledPackages.contains(packageName)
+    }
+
+    /**
+     * Saves the given package name to the preferences for media rpc. This is used to filter the
+     * media RPC based on the enabled media apps.
+     *
+     * If the package name is already saved, it will be removed. If it is not saved, it will be
+     * added.
+     *
+     * @param pkg The package name of the app to save
+     */
+    fun saveMediaAppToPrefs(pkg: String) {
+        val apps = get(ENABLED_MEDIA_APPS, Json.encodeToString(predefinedMediaApps))
+        val enabledPackages: ArrayList<String> = Json.decodeFromString(apps)
+        if (enabledPackages.contains(pkg))
+            enabledPackages.remove(pkg)
+        else
+            enabledPackages.add(pkg)
+
+        set(ENABLED_MEDIA_APPS, Json.encodeToString(enabledPackages))
+    }
+
     fun getUser(): User? {
         val userJson = get(USER_DATA, "")
         return when {
@@ -108,6 +140,7 @@ object Prefs {
     const val LAST_RUN_CUSTOM_RPC = "last_run_custom_rpc"
     const val LANGUAGE = "language"
     const val ENABLED_APPS = "enabled_apps"
+    const val ENABLED_MEDIA_APPS = "enabled_media_apps"
 
     //Media Rpc Preferences
     const val MEDIA_RPC_ARTIST_NAME = "media_rpc_artist_name"
@@ -150,4 +183,45 @@ object Prefs {
     const val LAST_DELETED = "last_deleted"
 
     const val CUSTOM_ACTIVITY_APPLICATION_ID = "custom_activity_application_id_"
+
+    /**
+     * The list of media apps that are enabled by default. See [isMediaAppEnabled] and
+     * [saveMediaAppToPrefs] for more information.
+     */
+    val predefinedMediaApps: List<String> = listOf(
+        // music steaming apps
+        "com.google.android.apps.youtube.music",
+        "com.spotify.music",
+        "com.google.android.music",
+        "com.amazon.mp3",
+        "com.apple.android.music",
+        "com.soundcloud.android",
+        "deezer.android.app",
+        "com.jrtstudio.AnotherMusicPlayer",
+        "com.pandora.android",
+        "com.rhapsody",
+        "com.sonyericsson.music",
+        "com.aspiro.tidal",
+
+        // music player apps
+        "com.sec.android.app.music",
+        "com.tbig.playerpro",
+
+        // video streaming apps
+        "com.google.android.apps.youtube.kids",
+        "com.google.android.apps.youtube.unplugged",
+        "com.google.android.youtube.googletv",
+        "com.google.android.youtube.tv",
+        "com.google.android.youtube",
+        "com.netflix.mediaclient",
+        "com.kick.mobile",
+        "tv.twitch.android.app",
+
+        // video player apps
+        "com.mxtech.videoplayer.ad",
+        "com.mxtech.videoplayer.pro",
+        "com.google.android.apps.mediashell",
+        "com.google.android.videos",
+        "org.videolan.vlc",
+    )
 }

--- a/feature_apps_rpc/build.gradle.kts
+++ b/feature_apps_rpc/build.gradle.kts
@@ -9,8 +9,6 @@ android {
 }
 
 dependencies {
-    implementation (libs.blankj.utilcodex)
-    implementation (libs.glide)
     implementation(projects.featureRpcBase)
     implementation (libs.material.icons.extended)
 }

--- a/feature_apps_rpc/src/main/java/com/my/kizzy/feature_apps_rpc/AppsRpc.kt
+++ b/feature_apps_rpc/src/main/java/com/my/kizzy/feature_apps_rpc/AppsRpc.kt
@@ -41,6 +41,7 @@ import com.my.kizzy.feature_rpc_base.services.ExperimentalRpc
 import com.my.kizzy.feature_rpc_base.services.MediaRpcService
 import com.my.kizzy.preference.Prefs
 import com.my.kizzy.resources.R
+import com.my.kizzy.ui.components.AppsItem
 import com.my.kizzy.ui.components.BackButton
 import com.my.kizzy.ui.components.SwitchBar
 import com.my.kizzy.ui.components.SearchBar

--- a/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaAppInfo.kt
+++ b/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaAppInfo.kt
@@ -1,0 +1,19 @@
+/*
+ *
+ *  ******************************************************************
+ *  *  * Copyright (C) 2022
+ *  *  * MediaAppInfo.kt is part of Kizzy
+ *  *  *  and can not be copied and/or distributed without the express
+ *  *  * permission of yzziK(Vaibhav)
+ *  *  *****************************************************************
+ *
+ *
+ */
+
+package com.my.kizzy.feature_media_rpc
+
+data class MediaAppInfo(
+    val name: String,
+    val pkg: String,
+    val isChecked: Boolean,
+)

--- a/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
+++ b/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
@@ -12,11 +12,16 @@
 
 package com.my.kizzy.feature_media_rpc
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.ResolveInfo
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -27,11 +32,14 @@ import androidx.compose.material.icons.filled.PauseCircle
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.my.kizzy.feature_rpc_base.AppUtils
 import com.my.kizzy.feature_rpc_base.services.AppDetectionService
 import com.my.kizzy.feature_rpc_base.services.CustomRpcService
@@ -45,8 +53,10 @@ import com.my.kizzy.preference.Prefs.MEDIA_RPC_ENABLE_TIMESTAMPS
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_HIDE_ON_PAUSE
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_SHOW_PLAYBACK_STATE
 import com.my.kizzy.resources.R
+import com.my.kizzy.ui.components.AppsItem
 import com.my.kizzy.ui.components.BackButton
 import com.my.kizzy.ui.components.SwitchBar
+import com.my.kizzy.ui.components.SearchBar
 import com.my.kizzy.ui.components.preference.PreferenceSwitch
 import com.my.kizzy.ui.components.preference.PreferencesHint
 
@@ -62,9 +72,18 @@ fun MediaRPC(onBackPressed: () -> Unit) {
     var hideOnPause by remember { mutableStateOf(Prefs[MEDIA_RPC_HIDE_ON_PAUSE, false]) }
     var isShowPlaybackState by remember { mutableStateOf(Prefs[MEDIA_RPC_SHOW_PLAYBACK_STATE, false]) }
     var hasNotificationAccess by remember { mutableStateOf(context.hasNotificationAccess()) }
+
+    var apps by remember { mutableStateOf(getInstalledApps(context)) }
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
+        rememberTopAppBarState(),
+        canScroll = { true })
+    var searchText by remember { mutableStateOf("") }
+    var isSearchBarVisible by remember { mutableStateOf(false) }
+
     Scaffold(
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             LargeTopAppBar(
                 title = {
@@ -73,11 +92,29 @@ fun MediaRPC(onBackPressed: () -> Unit) {
                         style = MaterialTheme.typography.headlineLarge,
                     )
                 },
-                navigationIcon = { BackButton { onBackPressed() } }
+                navigationIcon = { BackButton { onBackPressed() } },
+                actions = {
+                    if (isSearchBarVisible) {
+                        Column(
+                            modifier = Modifier.padding(10.dp)
+                        ) {
+                            SearchBar(
+                                text = searchText,
+                                onTextChanged = { searchText = it },
+                                onClose = { isSearchBarVisible = false },
+                                placeholder = stringResource(id = R.string.search_placeholder)
+                            )
+                        }
+                    } else {
+                        IconButton(onClick = { isSearchBarVisible = !isSearchBarVisible }) {
+                            Icon(imageVector = Icons.Outlined.Search, contentDescription = "Search")
+                        }
+                    }
+                },
+                scrollBehavior = scrollBehavior
             )
         }
     ) {
-
         Column(modifier = Modifier.padding(it)) {
             AnimatedVisibility(visible = !hasNotificationAccess
             ) {
@@ -140,7 +177,7 @@ fun MediaRPC(onBackPressed: () -> Unit) {
                         if (isAppIconEnabled) {
                             isShowPlaybackState = false
                             Prefs[MEDIA_RPC_SHOW_PLAYBACK_STATE] = false
-                      }
+                        }
                     }
                 }
                 item {
@@ -177,7 +214,67 @@ fun MediaRPC(onBackPressed: () -> Unit) {
                         Prefs[MEDIA_RPC_HIDE_ON_PAUSE] = hideOnPause
                     }
                 }
+                item {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+                items(apps.size) { i ->
+                    if (searchText.isEmpty() || apps[i].name.contains(
+                            searchText,
+                            ignoreCase = true
+                        ) || apps[i].pkg.contains(searchText, ignoreCase = true)
+                    ) {
+                        AppsItem(
+                            name = apps[i].name,
+                            pkg = apps[i].pkg,
+                            isChecked = apps[i].isChecked
+                        ) {
+                            apps = apps.mapIndexed { j, app ->
+                                if (i == j) {
+                                    Prefs.saveMediaAppToPrefs(app.pkg)
+                                    app.copy(isChecked = !app.isChecked)
+                                } else
+                                    app
+                            }
+                        }
+                    } else {
+                        Spacer(modifier = Modifier.height(0.dp))
+                    }
+                }
             }
         }
     }
+}
+
+private fun getInstalledApps(context: Context): List<MediaAppInfo> {
+    val appList: ArrayList<MediaAppInfo> = ArrayList()
+    val intent = Intent(Intent.ACTION_MAIN, null)
+    intent.addCategory(Intent.CATEGORY_LAUNCHER)
+    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+    val resolveInfoList: List<ResolveInfo> =
+        context.packageManager.queryIntentActivities(intent, 0)
+
+    for (resolveInfo in resolveInfoList) {
+        val activityInfo = resolveInfo.activityInfo
+
+        if (resolveInfo.isSystemPackage()) continue
+
+        appList.add(
+            MediaAppInfo(
+                name = context.packageManager.getApplicationLabel(activityInfo.applicationInfo).toString(),
+                pkg = activityInfo.applicationInfo.packageName,
+                isChecked = Prefs.isMediaAppEnabled(activityInfo.packageName),
+            )
+        )
+    }
+
+    return appList.sortedBy { it.name }.sortedBy { !it.isChecked }
+}
+
+private fun ResolveInfo.isSystemPackage(): Boolean {
+    // If the app is a predefined media app, return false even if it is a system app. (e.g. YouTube)
+    if (Prefs.predefinedMediaApps.contains(this.activityInfo.packageName)) return false
+
+    return this.activityInfo.applicationInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0
 }


### PR DESCRIPTION
* The app allows to determine the applications will be used for media rpc. The applications are set in MediaRpc.kt screen and the feature will be work for both media rpc and experimental rpc.

* In Prefs.kt new functions are created to enable media apps. And, default media apps are defined as default.
* GetCurrentlyPlayingMedia.kt is updated to check all media sessions and checks for the application is enabled in Prefs.kt.
* AppsItem.kt moved to common/components module.
* MediaRpc.kt is updated to list all apps and allows toggling them for media rpc.