### PR TITLE
Show song name as title

### DIFF
--- a/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
+++ b/common/preference/src/main/java/com/my/kizzy/preference/Prefs.kt
@@ -152,6 +152,7 @@ object Prefs {
     const val MEDIA_RPC_ENABLE_TIMESTAMPS = "enable_timestamps"
     const val MEDIA_RPC_HIDE_ON_PAUSE = "hide_on_pause"
     const val MEDIA_RPC_SHOW_PLAYBACK_STATE = "show_playback_state"
+    const val MEDIA_RPC_SHOW_SONG_AS_TITLE = "show_song_as_title"
 
     //Rpc Setting Preferences
     const val USE_RPC_BUTTONS = "use_saved_rpc_buttons"

--- a/common/resources/src/main/res/values/strings.xml
+++ b/common/resources/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="clear">Clear</string>
     <string name="search_placeholder">Search…</string>
     <string name="hide_on_pause">Hide RPC on Pause</string>
+    <string name="show_song_as_title">Show song as title</string>
     <string name="idling_notification">Idling…</string>
     <string name="main_appDetection">App Detection</string>
     <string name="main_appDetection_details">Kizzy allows you to share your current activity on Discord by detecting what app you\'re using on your device.</string>

--- a/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
+++ b/data/src/main/java/com/my/kizzy/data/get_current_data/media/GetCurrentlyPlayingMedia.kt
@@ -112,15 +112,31 @@ class GetCurrentPlayingMedia @Inject constructor(
                     smallText = null
                 }
 
-                return CommonRpc(name = appName,
-                    details = title,
-                    state = author,
-                    largeImage = largeIcon,
-                    smallImage = smallIcon,
-                    largeText = album,
-                    smallText = smallText,
-                    packageName = "$title::${mediaController.packageName}",
-                    time = timestamps.takeIf { it != null })
+                return if (Prefs[Prefs.MEDIA_RPC_SHOW_SONG_AS_TITLE, false]) {
+                    CommonRpc(
+                        name = title,
+                        details = author,
+                        state = album,
+                        largeImage = largeIcon,
+                        smallImage = smallIcon,
+                        largeText = appName,
+                        smallText = smallText,
+                        packageName = "$title::${mediaController.packageName}",
+                        time = timestamps.takeIf { it != null }
+                    )
+                } else {
+                    CommonRpc(
+                        name = appName,
+                        details = title,
+                        state = author,
+                        largeImage = largeIcon,
+                        smallImage = smallIcon,
+                        largeText = album,
+                        smallText = smallText,
+                        packageName = "$title::${mediaController.packageName}",
+                        time = timestamps.takeIf { it != null }
+                    )
+                }
             }
         }
         return CommonRpc()

--- a/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
+++ b/feature_media_rpc/src/main/java/com/my/kizzy/feature_media_rpc/MediaRpc.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.filled.PlaylistAddCircle
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -65,6 +66,7 @@ import com.my.kizzy.preference.Prefs.MEDIA_RPC_ARTIST_NAME
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_ENABLE_TIMESTAMPS
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_HIDE_ON_PAUSE
 import com.my.kizzy.preference.Prefs.MEDIA_RPC_SHOW_PLAYBACK_STATE
+import com.my.kizzy.preference.Prefs.MEDIA_RPC_SHOW_SONG_AS_TITLE
 import com.my.kizzy.resources.R
 import com.my.kizzy.ui.components.AppsItem
 import com.my.kizzy.ui.components.BackButton
@@ -90,6 +92,7 @@ fun MediaRPC(
     var isTimestampsEnabled by remember { mutableStateOf(Prefs[MEDIA_RPC_ENABLE_TIMESTAMPS, false]) }
     var hideOnPause by remember { mutableStateOf(Prefs[MEDIA_RPC_HIDE_ON_PAUSE, false]) }
     var isShowPlaybackState by remember { mutableStateOf(Prefs[MEDIA_RPC_SHOW_PLAYBACK_STATE, false]) }
+    var showSongAsTitle by remember { mutableStateOf(Prefs[Prefs.MEDIA_RPC_SHOW_SONG_AS_TITLE, false]) }
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState(),
@@ -230,6 +233,16 @@ fun MediaRPC(
                     ) {
                         hideOnPause = !hideOnPause
                         Prefs[MEDIA_RPC_HIDE_ON_PAUSE] = hideOnPause
+                    }
+                }
+                item {
+                    PreferenceSwitch(
+                        title = stringResource(id = R.string.show_song_as_title),
+                        icon = Icons.Default.PlaylistAddCircle,
+                        isChecked = showSongAsTitle,
+                    ) {
+                        showSongAsTitle = !showSongAsTitle
+                        Prefs[MEDIA_RPC_SHOW_SONG_AS_TITLE] = showSongAsTitle
                     }
                 }
                 item {


### PR DESCRIPTION
I've added a new preference, that allows the users to show the song name as the title instead of the app name

Bellow are some screenshots with the changes

In app view:
![telegram-cloud-photo-size-4-6025938059905846038-w](https://github.com/user-attachments/assets/29770bbf-cf90-46de-89aa-1c8e4ecd16ca)

When the option is disabled (default):
<img width="440" height="379" alt="image" src="https://github.com/user-attachments/assets/80bf75ee-a7ce-4191-9be6-7341d94cbce4" />
<img width="266" height="62" alt="image" src="https://github.com/user-attachments/assets/dcde4066-7649-4797-a5d2-bba958db0dbb" />

When preference is enabled:
<img width="341" height="173" alt="image" src="https://github.com/user-attachments/assets/b76a2847-5774-40b5-a708-568f52ee6a38" />
<img width="263" height="57" alt="image" src="https://github.com/user-attachments/assets/97062afd-cf93-4c70-8989-d903742bd5ab" />


Extra: how it looks if Artist Name and Album Name are disabled
<img width="603" height="130" alt="image" src="https://github.com/user-attachments/assets/7ea988eb-79d4-4a6c-9eb4-59d40a767912" />
<img width="349" height="77" alt="image" src="https://github.com/user-attachments/assets/2b10fa88-a8c2-4ab1-922e-d340db866d4b" />

Extra: how it looks with a song with in album
<img width="596" height="135" alt="image" src="https://github.com/user-attachments/assets/8656a431-4df4-4ac8-adad-366546935bec" />
