### PR TITLE
Fix issue #432

### DIFF
--- a/data/src/main/java/com/my/kizzy/data/rpc/CommonRpc.kt
+++ b/data/src/main/java/com/my/kizzy/data/rpc/CommonRpc.kt
@@ -14,6 +14,7 @@ package com.my.kizzy.data.rpc
 
 data class CommonRpc(
     val name: String = "",
+    val type: Int? = null,
     val details: String? = "",
     val state: String? = "",
     val partyCurrentSize: Int? = null,

--- a/data/src/main/java/com/my/kizzy/data/rpc/KizzyRPC.kt
+++ b/data/src/main/java/com/my/kizzy/data/rpc/KizzyRPC.kt
@@ -323,7 +323,7 @@ class KizzyRPC(
                         name = commonRpc.name,
                         details = commonRpc.details?.takeIf { it.isNotEmpty() }?.sanitize(),
                         state = commonRpc.state?.takeIf { it.isNotEmpty() }?.sanitize(),
-                        type = Prefs[CUSTOM_ACTIVITY_TYPE, 0],
+                        type = commonRpc.type ?: Prefs[CUSTOM_ACTIVITY_TYPE, 0],
                         platform = commonRpc.platform?.sanitize(),
                         timestamps = time.takeIf { enableTimestamps == true },
                         assets = Assets(

--- a/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/ExperimentalRpc.kt
+++ b/feature_rpc_base/src/main/java/com/my/kizzy/feature_rpc_base/services/ExperimentalRpc.kt
@@ -322,6 +322,7 @@ class ExperimentalRpc : Service() {
             kizzyRPC.updateRPC(
                 commonRpc = CommonRpc(
                     name = finalName ?: "",
+                    type = appActivityTypes[effectivePackageName] ?: 0,
                     details = finalDetails,
                     state = finalState,
                     largeImage = finalLargeImage,


### PR DESCRIPTION
## Issue Explanation

The issue occurred because of the code inside `ExperimentalRpc.kt`.

The function `kizzyRPC.updateRPC()` didn’t forward the **type information**, unlike `kizzyRPC.apply()`, which has a `setType` function.

As a result, the `type` value was only set correctly during the first `apply()` call.  
When updating, since the type information wasn’t forwarded, it defaulted to `0`.

---

## Fix Applied

A `type` parameter was added to `commonRPC` to allow forwarding **type information** from `ExperimentalRpc.kt` to `kizzyRPC.updateRPC()`.

This ensures that the type value is preserved and correctly applied during subsequent updates.
