### PR TITLE
fix(fileprovider): add external-path for Download/Kizzy to prevent crash

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -3,4 +3,8 @@
     <files-path
         name="files"
         path="." />
+
+    <external-path
+        name="downloads"
+        path="Download/" />
 </paths>


### PR DESCRIPTION
# Fix FileProvider crash when exporting custom RPC config

## Summary
This PR fixes a crash that occurs on Android 13 and above when exporting a custom RPC configuration file located under `Download/Kizzy/`.  
`FileProvider` was not configured to expose external `Download/` paths, leading to an `IllegalArgumentException` when generating a `content://` URI.

## Root cause
Starting from Android 13, scoped storage enforcement became stricter.  
`FileProvider` only allows sharing files from roots explicitly declared in `res/xml/provider_paths.xml`. 

Since `/storage/emulated/0/Download/Kizzy/<name>.json` was outside the configured roots (which only included `files-path`), the system threw:
```txt
IllegalArgumentException: Failed to find configured root that contains /storage/emulated/0/Download/Kizzy/<name>.json
```

## Changes
- Added `<external-path name="downloads" path="Download/" />` to `res/xml/provider_paths.xml` to allow sharing files from `Download/` and its subdirectories (including `Download/Kizzy/`).
- This resolves the crash occurring when exporting or sharing custom RPC config files.

## provider_paths.xml (updated)
```xml
<?xml version="1.0" encoding="utf-8"?>
<paths xmlns:android="http://schemas.android.com/apk/res/android">
    <files-path
        name="files"
        path="." />
    <!-- Allow sharing files inside Download/ (includes Download/Kizzy/) -->
    <external-path
        name="downloads"
        path="Download/" />
</paths>
```