### PR TITLE
fix timezone offset issue in custom rpc timestamp picker

### DIFF
--- a/feature_custom_rpc/src/main/java/com/my/kizzy/feature_custom_rpc/components/DateTimePicker.kt
+++ b/feature_custom_rpc/src/main/java/com/my/kizzy/feature_custom_rpc/components/DateTimePicker.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.my.kizzy.resources.R
 import java.util.Calendar
+import java.util.TimeZone
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -192,12 +193,21 @@ internal fun getDateTimeInMillis(
     hours: Int,
     minutes: Int,
 ): Long {
-    val calender = Calendar.getInstance().apply {
+    val utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
         timeInMillis = dateMillis
-        set(Calendar.HOUR_OF_DAY, hours % 12 + if (hours >= 12) 12 else 0)
-        set(Calendar.MINUTE, minutes)
     }
-    return calender.timeInMillis
+    
+    val localCalendar = Calendar.getInstance().apply {
+        set(Calendar.YEAR, utcCalendar.get(Calendar.YEAR))
+        set(Calendar.MONTH, utcCalendar.get(Calendar.MONTH))
+        set(Calendar.DAY_OF_MONTH, utcCalendar.get(Calendar.DAY_OF_MONTH))
+        set(Calendar.HOUR_OF_DAY, hours)
+        set(Calendar.MINUTE, minutes)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+    
+    return localCalendar.timeInMillis
 }
 
 @Preview


### PR DESCRIPTION
hey, i noticed theres an issue with the custom rpc timestamp picker where selecting the current date causes discord to show "playing for 24 hours" instead of the correct time, to get the right timestamp users have to select the next day which is obviously not ideal

i looked into the code and found that the problem is in the getDateTimeInMillis function in DateTimePicker.kt, the datepicker returns timestamps in utc at midnight but when calendar.getinstance processes this value with the local timezone it shifts the date by one day for users in negative utc offsets like gmt-3

this pr changes the function to properly extract the date components from the utc timestamp and then create a new calendar instance in the local timezone with those values plus the user selected time, this should prevent the date shifting issue

i havent tested this myself since i dont have a test environment set up right now but the logic should fix the timezone conversion problem, would appreciate if you could review this and test it out.

thanks.