### PR TITLE
fix crash on android 16 by removing minsdk restriction on foreground service permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,9 +24,7 @@
     <uses-permission
         android:name="android.permission.POST_NOTIFICATIONS"
         android:minSdkVersion="33" />
-    <uses-permission
-        android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
-        android:minSdkVersion="34" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <application
         android:name=".App"


### PR DESCRIPTION
fixes the crash reported in issue 477 where the app would immediately crash when enabling any rpc feature on android 16

the problem was that the foreground service media playback permission had a minsdk version restriction which prevented it from being properly declared for apps targeting sdk 36

removed the android minsdk version attribute from the permission so it applies to all versions including android 16

tested the manifest changes and this should resolve the security exception that was preventing the mediarpcservice from starting

closes 477